### PR TITLE
MNT: Update codecov-action version to v2

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -43,7 +43,7 @@ jobs:
     # # This is an example of how to upload coverage to codecov
     # - name: Upload coverage to codecov
     #   if: matrix.tox-env == 'cov' && matrix.python-ver == '8'
-    #   uses: codecov/codecov-action@v1
+    #   uses: codecov/codecov-action@v2
     #   with:
     #     token: ${{ secrets.CODECOV }}
     #     file: ./coverage.xml


### PR DESCRIPTION
You are using a deprecated version of `codecov-action`, see https://github.com/codecov/codecov-action for more details. xref astropy/astropy#12245

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.