### PR TITLE
Update tests and CI to use python 3.8 and 3.9

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -21,8 +21,8 @@ jobs:
         # For example -- os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
 
-        # Test python 3.7, and 3.8 by default.
-        python-ver: [7, 8]
+        # Test python 3.8, and 3.9 by default.
+        python-ver: [8, 9]
 
         # Specify which tox environments to test in this list.
         tox-env: [cov, alldeps, devdeps, astropylts]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37,38}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37,38}-test-numpy{116,117,118}
-    py{36,37,38}-test-astropy{30,40,lts}
+    py{38,39}-test{,-devdeps,-datadeps}{,-cov}
+    py{38,39}-test-numpy{118,119,120,121}
+    py{38,39}-test-astropy{lts}
     build_docs
     codestyle
 requires =
@@ -33,22 +33,20 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy116: with numpy 1.16.*
-    numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
-    astropy30: with astropy 3.0.*
-    astropy40: with astropy 4.0.*
+    numpy119: with numpy 1.19.*
+    numpy120: with numpy 1.20.*
+    numpy121: with numpy 1.21.*
     astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
 deps =
 
-    numpy116: numpy==1.16.*
-    numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
+    numpy119: numpy==1.19.*
+    numpy120: numpy==1.20.*
+    numpy121: numpy==1.21.*
 
-    astropy30: astropy==3.0.*
-    astropy40: astropy==4.0.*
     astropylts: astropy==4.0.*
 
     devdeps: git+https://github.com/numpy/numpy.git#egg=numpy


### PR DESCRIPTION
This PR updates the testing and CI to use python 3.8 and 3.9. Some of the dev dependencies no longer support 3.7 and there's little point for this repo to support anything < 3.8. 